### PR TITLE
Change device for i2c for Odroid xu3 & xu4

### DIFF
--- a/wiringPi/wiringPiI2C.c
+++ b/wiringPi/wiringPiI2C.c
@@ -226,7 +226,7 @@ int wiringPiI2CSetup (const int devId)
   if      ( model == PI_MODEL_ODROIDC || model == PI_MODEL_ODROIDC2 )
     device = "/dev/i2c-1" ;
   else if ( model == PI_MODEL_ODROIDXU_34 )
-    device = "/dev/i2c-4" ;	/* update 2016/feb/12 Linux */
+    device = "/dev/i2c-3" ;	/* update 2016/feb/12 Linux */
   else  {
     rev = piBoardRev () ;
 


### PR DESCRIPTION
In my case (odroid xu4), I had to use /dev/i2c-3. Also more info here: http://odroid.com/dokuwiki/doku.php?id=en:xu3_hardware_i2c. There also the i2c-3 is used.
