### PR TITLE
wiringPi: Apply unused attribute.

### DIFF
--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -183,7 +183,7 @@ static void checkDevTree (char *argv [])
 	}
 }
 
-static void doLoad (int argc, char *argv [])
+static void doLoad (int UNU argc, char *argv [])
 {
 	checkDevTree (argv) ;
 }
@@ -194,7 +194,7 @@ static void doLoad (int argc, char *argv [])
  *	Un-Load either the spi or i2c modules and change device ownerships, etc.
  *********************************************************************************
  */
-static void doUnLoad (int argc, char *argv [])
+static void doUnLoad (int UNU argc, char *argv [])
 {
 	checkDevTree (argv) ;
 }
@@ -725,7 +725,7 @@ static void doWrite (int argc, char *argv [])
  *********************************************************************************
  */
 
-static void doAwrite (int argc, char *argv [])
+static void UNU doAwrite (int argc, char *argv [])
 {
 	int pin, val ;
 
@@ -937,12 +937,12 @@ void doPwm (int argc, char *argv [])
  *********************************************************************************
  */
 
-static void doPwmMode (int mode)
+static void UNU doPwmMode (int mode)
 {
 	pwmSetMode (mode) ;
 }
 
-static void doPwmRange (int argc, char *argv [])
+static void UNU doPwmRange (int argc, char *argv [])
 {
 	unsigned int range ;
 
@@ -960,7 +960,7 @@ static void doPwmRange (int argc, char *argv [])
 	pwmSetRange (range) ;
 }
 
-static void doPwmClock (int argc, char *argv [])
+static void UNU doPwmClock (int argc, char *argv [])
 {
 	unsigned int clock ;
 
@@ -983,7 +983,7 @@ static void doPwmClock (int argc, char *argv [])
  *	function is not support by ODROID Board.
  *********************************************************************************
  */
-static void doNothing (int argc, char *argv [])
+static void doNothing (int UNU argc, char *argv [])
 {
 	fprintf(stderr, "warn : (%s) : This function is not supported by ODROID Board.\n",
 		argv[1]);

--- a/gpio/readall.c
+++ b/gpio/readall.c
@@ -296,7 +296,7 @@ static const char *physNamesOdroidN2 [64] =
 } ;
 
 /*----------------------------------------------------------------------------*/
-static void readallPhysOdroid (int model, int rev, int physPin, const char *physNames[])
+static void readallPhysOdroid (int model, int UNU rev, int physPin, const char *physNames[])
 {
 	int pin ;
 

--- a/wiringPi/odroidn1.c
+++ b/wiringPi/odroidn1.c
@@ -266,7 +266,7 @@ static void setIomuxMode (int pin, int mode)
 static void _pinMode (int pin, int mode)
 {
 	int origPin, bank;
-	unsigned long flags;
+	unsigned long UNU flags;
 
 	if (lib->mode == MODE_GPIO_SYS)
 		return;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -176,18 +176,18 @@ static void warn_msg(const char *func)
 // Unsupport Function list on ODROIDs
 //
 /*----------------------------------------------------------------------------*/
-static 	void piGpioLayoutOops	(const char *why)	{ warn_msg(__func__); return; }
-	void pwmSetMode		(int mode)		{ warn_msg(__func__); return; }
-	void pwmSetRange	(unsigned int range)	{ warn_msg(__func__); return; }
-	void pwmSetClock	(int divisor)		{ warn_msg(__func__); return; }
-	void gpioClockSet	(int pin, int freq)	{ warn_msg(__func__); return; }
+static 	void piGpioLayoutOops	(const char UNU *why)	{ warn_msg(__func__); return; }
+	void pwmSetMode		(int UNU mode)		{ warn_msg(__func__); return; }
+	void pwmSetRange	(unsigned int UNU range)	{ warn_msg(__func__); return; }
+	void pwmSetClock	(int UNU divisor)		{ warn_msg(__func__); return; }
+	void gpioClockSet	(int UNU pin, int UNU freq)	{ warn_msg(__func__); return; }
 
 	/* core unsupport function */
-	void pinModeAlt		(int pin, int mode)	{ warn_msg(__func__); return; }
-	void pwmWrite		(int pin, int value)	{ warn_msg(__func__); return; }
-	void analogWrite	(int pin, int value)	{ warn_msg(__func__); return; }
-	void pwmToneWrite	(int pin, int freq)	{ warn_msg(__func__); return; }
-	void digitalWriteByte2	(const int value)	{ warn_msg(__func__); return; }
+	void pinModeAlt		(int UNU pin, int UNU mode)	{ warn_msg(__func__); return; }
+	void pwmWrite		(int UNU pin, int UNU value)	{ warn_msg(__func__); return; }
+	void analogWrite	(int UNU pin, int UNU value)	{ warn_msg(__func__); return; }
+	void pwmToneWrite	(int UNU pin, int UNU freq)	{ warn_msg(__func__); return; }
+	void digitalWriteByte2	(const int UNU value)	{ warn_msg(__func__); return; }
 	unsigned int digitalReadByte2 (void)		{ warn_msg(__func__); return -1; }
 /*----------------------------------------------------------------------------*/
 // Extend wiringPi with other pin-based devices and keep track of
@@ -195,7 +195,7 @@ static 	void piGpioLayoutOops	(const char *why)	{ warn_msg(__func__); return; }
 /*----------------------------------------------------------------------------*/
 struct wiringPiNodeStruct *wiringPiNodes = NULL ;
 
-struct wiringPiNodeStruct *wiringPiFindNode (int pin) {	return NULL; }
+struct wiringPiNodeStruct *wiringPiFindNode (int UNU pin) {	return NULL; }
 
 static		void pinModeDummy		(UNU struct wiringPiNodeStruct *node, UNU int pin, UNU int mode)  { return ; }
 static		void pullUpDnControlDummy	(UNU struct wiringPiNodeStruct *node, UNU int pin, UNU int pud)   { return ; }

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -267,17 +267,17 @@ extern		int  wpiPinToGpio	(int wpiPin);
 extern		int  physPinToGpio	(int physPin);
 
 // Unsupported
-extern		void pinModeAlt		(int pin, int mode);
-extern		void analogWrite	(int pin, int value);
-extern		void pwmToneWrite	(int pin, int freq);
-extern		void pwmSetMode		(int mode);
-extern		void pwmSetRange	(unsigned int range);
-extern		void pwmSetClock	(int divisor);
-extern		void gpioClockSet	(int pin, int freq);
-extern unsigned int  digitalReadByte	(void);
-extern unsigned int  digitalReadByte2	(void);
-extern		void digitalWriteByte	(int value);
-extern		void digitalWriteByte2	(int value);
+extern		void pinModeAlt		(int pin, int mode) UNU;
+extern		void analogWrite	(int pin, int value) UNU;
+extern		void pwmToneWrite	(int pin, int freq) UNU;
+extern		void pwmSetMode		(int mode) UNU;
+extern		void pwmSetRange	(unsigned int range) UNU;
+extern		void pwmSetClock	(int divisor) UNU;
+extern		void gpioClockSet	(int pin, int freq) UNU;
+extern unsigned int  digitalReadByte	(void) UNU;
+extern unsigned int  digitalReadByte2	(void) UNU;
+extern		void digitalWriteByte	(int value) UNU;
+extern		void digitalWriteByte2	(int value) UNU;
 
 // Interrupt
 extern		int  waitForInterrupt	(int pin, int mS);


### PR DESCRIPTION
To avoid error message, apply "__attribute__((unused))" to unsupported
functions and unused parameters.