### PR TITLE
android: pthread: replace pthread_cancel.

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -108,6 +108,14 @@ const int piMemorySize [8] =
 static volatile int    pinPass = -1 ;
 static pthread_mutex_t pinMutex ;
 
+/*----------------------------------------------------------------------------*/
+#ifdef __ANDROID__
+int pthread_cancel(pthread_t h) {
+    return pthread_kill(h, 0);
+}
+#endif /* __ANDROID__ */
+/*----------------------------------------------------------------------------*/
+
 // Debugging & Return codes
 int wiringPiDebug       = FALSE ;
 int wiringPiReturnCodes = FALSE ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -700,6 +700,15 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
 					WPI_FATAL,
 					"wiringPiISR: execl failed: %s\n",
 					strerror (errno));
+#ifdef __ANDROID__
+			} else if (access("/system/bin/gpio", X_OK) == 0) {
+				execl ("/system/bin/gpio", "gpio", "edge",
+					pinS, modeS, (char *)NULL) ;
+				return wiringPiFailure (
+					WPI_FATAL,
+					"wiringPiISR: execl failed: %s\n",
+					strerror (errno));
+#endif
 			} else
 				return wiringPiFailure (
 					WPI_FATAL,


### PR DESCRIPTION
- android doesn't support pthread_cancel. so use pthread_kill instead
  pthread_cacnel.