### PR TITLE
android specific patches.

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -108,6 +108,14 @@ const int piMemorySize [8] =
 static volatile int    pinPass = -1 ;
 static pthread_mutex_t pinMutex ;
 
+/*----------------------------------------------------------------------------*/
+#ifdef __ANDROID__
+int pthread_cancel(pthread_t h) {
+    return pthread_kill(h, 0);
+}
+#endif /* __ANDROID__ */
+/*----------------------------------------------------------------------------*/
+
 // Debugging & Return codes
 int wiringPiDebug       = FALSE ;
 int wiringPiReturnCodes = FALSE ;


### PR DESCRIPTION
- pthread_cancel -> pthread_kill, pthread_cancel is not supported.

- because of permission problem, android service can't use 'gpio edge' command. so directly touched the gpio nodes.