### PR TITLE
Add wiringPiSPISetupInterface

### DIFF
--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -38,13 +38,13 @@
 // The SPI bus parameters
 //	Variables as they need to be passed as pointers later on
 
-static const char       *spiDevType0    = "/dev/spidev0.0";
-static const char       *spiDevType1    = "/dev/spidev1.0";
+static const char       *spiDevType0    = "/dev/spidev0.";
+static const char       *spiDevType1    = "/dev/spidev1.";
 static const uint8_t     spiBPW         = 8;
 static const uint16_t    spiDelay       = 0;
 
-static uint32_t    spiSpeeds [2] ;
-static int         spiFds [2] ;
+static uint32_t    spiSpeeds [8];
+static int         spiFds [8];
 
 
 /*
@@ -55,7 +55,7 @@ static int         spiFds [2] ;
 
 int wiringPiSPIGetFd (int channel)
 {
-  return spiFds [channel & 1] ;
+  return spiFds [channel & 0x7] ;
 }
 
 
@@ -72,7 +72,7 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
 {
   struct spi_ioc_transfer spi ;
 
-  channel &= 1 ;
+  channel &= 0x7 ;
 
 // Mentioned in spidev.h but not used in the original kernel documentation
 //	test program )-:
@@ -89,6 +89,41 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
   return ioctl (spiFds [channel], SPI_IOC_MESSAGE(1), &spi) ;
 }
 
+/*
+ * wiringPiSPISetupInterface:
+ *	Open the SPI device, and set it up, with the mode, etc.
+ *********************************************************************************
+ */
+
+int wiringPiSPISetupInterface	(const char *device, int channel, int speed, int mode)
+{
+	int fd ;
+
+	channel &= 0x7;
+	mode    &= 3;
+
+	if ((fd = open (device, O_RDWR)) < 0)
+		return wiringPiFailure (WPI_ALMOST,
+			"Unable to open %s: %s\n",device , strerror (errno));
+
+	spiSpeeds [channel] = speed ;
+	spiFds    [channel] = fd ;
+
+	// Set SPI parameters.
+	if (ioctl (fd, SPI_IOC_WR_MODE, &mode) < 0)
+		return wiringPiFailure (WPI_ALMOST,
+			"SPI Mode Change failure: %s\n", strerror (errno));
+
+	if (ioctl (fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0)
+		return wiringPiFailure (WPI_ALMOST,
+			"SPI BPW Change failure: %s\n", strerror (errno));
+
+	if (ioctl (fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0)
+		return wiringPiFailure (WPI_ALMOST,
+			"SPI Speed Change failure: %s\n", strerror (errno));
+
+	return fd ;
+}
 
 /*
  * wiringPiSPISetupMode:
@@ -98,55 +133,29 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
 
 int wiringPiSPISetupMode (int channel, int speed, int mode)
 {
-	int fd ;
-	int model, rev, mem, maker, overVolted ;
-	const char *device ;
+	char device[25];
+	int model, temp;
 
-	piBoardId (&model, &rev, &mem, &maker, &overVolted) ;
-
-	mode    &= 3 ;	// Mode is 0, 1, 2 or 3
-	channel &= 1 ;	// Channel is 0 or 1
+	piBoardId (&model, &temp, &temp, &temp, &temp) ;
 
 	if (model == MODEL_ODROID_C2) {
 		return wiringPiFailure (WPI_ALMOST,
-			"Can't support spi device. check model or spi channel.\n");
+			"ODROID C2 does not support hardware SPI. Check out the SPI bitbang and use wiringPiSPISetupInterface.\n");
 	}
 
 	switch(model)	{
 	case MODEL_ODROID_C1:
-		device = spiDevType0;
+	case MODEL_ODROID_N2:
+		sprintf(device, "%s%d", spiDevType0, channel);
 	break;
 	case MODEL_ODROID_XU3:
 	case MODEL_ODROID_N1:
-		device = spiDevType1;
-	break;
-	case MODEL_ODROID_N2:
-		device = spiDevType0;
+		sprintf(device, "%s%d", spiDevType1, channel);
 	break;
 	}
 
-	if ((fd = open (device, O_RDWR)) < 0)
-		return wiringPiFailure (WPI_ALMOST,
-			"Unable to open SPI device: %s\n", strerror (errno));
-
-	spiSpeeds [channel] = speed ;
-	spiFds    [channel] = fd ;
-
-	// Set SPI parameters.
-	if (ioctl (fd, SPI_IOC_WR_MODE, &mode) < 0)
-		return wiringPiFailure (WPI_ALMOST,
-			"SPI Mode Change failure: %s\n", strerror (errno)) ;
-
-	if (ioctl (fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0)
-		return wiringPiFailure (WPI_ALMOST,
-			"SPI BPW Change failure: %s\n", strerror (errno)) ;
-
-	if (ioctl (fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0)
-		return wiringPiFailure (WPI_ALMOST,
-			"SPI Speed Change failure: %s\n", strerror (errno)) ;
-	return fd ;
+	return wiringPiSPISetupInterface(device, channel, speed, mode);
 }
-
 
 /*
  * wiringPiSPISetup:

--- a/wiringPi/wiringPiSPI.h
+++ b/wiringPi/wiringPiSPI.h
@@ -26,10 +26,12 @@
 extern "C" {
 #endif
 
-int wiringPiSPIGetFd     (int channel) ;
-int wiringPiSPIDataRW    (int channel, unsigned char *data, int len) ;
-int wiringPiSPISetupMode (int channel, int speed, int mode) ;
-int wiringPiSPISetup     (int channel, int speed) ;
+int wiringPiSPIGetFd	(int channel) ;
+int wiringPiSPIDataRW	(int channel, unsigned char *data, int len) ;
+
+int wiringPiSPISetupInterface	(const char *device, int channel, int speed, int mode) ;
+int wiringPiSPISetupMode	(int channel, int speed, int mode) ;
+int wiringPiSPISetup		(int channel, int speed) ;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
wiringPi did not support device selection.
When adding an SPI device or  SPI CS, a user could not use wiringPiSPI.h.

If using wiringPiSPISetupInterface, a user can select an SPI device.