### PR TITLE
WiringPi: Android: Redefine some function that's not supported.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -47,7 +47,6 @@ cc_library_shared {
         "wiringPi/mcp3422.c",
         "wiringPi/pcf8591.c",
         "wiringPi/softTone.c",
-        "wiringPi/wpiExtensions.c",
     ],
 
     vendor_available: true,

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -31,6 +31,11 @@
 
 /*----------------------------------------------------------------------------*/
 
+#ifdef __ANDROID__
+#define __bswap_16(x)	bswap_16(x)
+#define __bswap_32(x)	bswap_32(x)
+#endif
+
 #ifndef	TRUE
 #define	TRUE	(1==1)
 #define	FALSE	(!TRUE)


### PR DESCRIPTION
- Some api are not supported or redefined by android libraries. So to
support them on the android, this patch redefined the apis.

-some api are not allowed by seLinux. So avoid including the package by the problem.