### PR TITLE
WiringPi: Android: Add N2Plus to ModelNames list.

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -57,7 +57,7 @@ const char *piModelNames [16] =
 	"ODROID-C2",
 	"ODROID-XU3/XU4",
 	"ODROID-N1",
-	"ODROID-N2",
+	"ODROID-N2/N2Plus",
 	"ODROID-C4",
 };
 


### PR DESCRIPTION
- Add N2Plus to default N2 string.

Change-Id: I0a04d57ec1ffcb6ca63b78275df52243abccb02e