### PR TITLE
Update odroidc4.c

### DIFF
--- a/wiringPi/odroidc4.c
+++ b/wiringPi/odroidc4.c
@@ -422,7 +422,7 @@ static int _getPUPD (int pin)
 	shift = gpioToShiftReg(pin);
 
 	if (*(gpio + puen) & (1 << shift))
-		return *(gpio + pupd) & (1 << shift) ? 1 : 2;
+		return *(gpio + pupd) & (1 << shift) ? 2 : 1;
 	else
 		return 0;
 }


### PR DESCRIPTION
_pullUpDnControl when called with PUD_UP sets a bit... That's in line with datasheet that says 1 = pull up.
_getPUPD when the bit is set returns PUD_DOWN...